### PR TITLE
Bind tkgui frame queue after init

### DIFF
--- a/src/orbitalcoms/_app/tkgui.py
+++ b/src/orbitalcoms/_app/tkgui.py
@@ -35,7 +35,6 @@ class GroundStationFrame(tk.Frame):
     def __init__(self, gs: GroundStation, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._gs = gs
-        self._gs.bind_queue(GroundStationFrame.FrameUpdateQueue(self))
 
         # Config Window
         self.grid(column=0, row=0, sticky="nsew")
@@ -88,6 +87,7 @@ class GroundStationFrame(tk.Frame):
         self.txt_sent = tk.Text(self)
         self.txt_recv = tk.Text(self)
         self.txt_data = tk.Text(self)
+        self._gs.bind_queue(GroundStationFrame.FrameUpdateQueue(self))
 
         self.txt_sent.grid(column=1, row=0, rowspan=5, sticky="nsew")
         self.txt_recv.grid(column=2, row=0, rowspan=5, sticky="nsew")


### PR DESCRIPTION
This PR moves when the tkgui frame queue is append.

Previously, the frame queue was bound prior to initializing when the tk elements that were updated where initialized. This means that was possible for an incoming message to be received prior to the gui elements being initialized, resulting in an error being raise during the queue `append` method, and thus crashing the message receiving thread.

By simply moving where the frame queue is bound to after the tk elements have been initialized, we can ensure this is never a problem.